### PR TITLE
Move function call precedence above assignment

### DIFF
--- a/src/r.grammar
+++ b/src/r.grammar
@@ -4,8 +4,8 @@
 
 @precedence {
   else @right,
-  assign @right,
   call @right,
+  assign @right,
   break @left,
   next @left,
   ns @left,

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -33,6 +33,7 @@ fn()
 fn(arg1, arg2, ...)
 fn(arg1, arg2 = 123, arg3 = , "arg4" = xyz, ...)
 "fn"()
+foo <- fn(arg1, ...)
 
 ==>
 
@@ -40,7 +41,8 @@ Script(FunctionCall(FunctionDeclaration(function,ParamList,Block(BlockOpenBrace,
   FunctionCall(Identifier,ArgList),
   FunctionCall(Identifier,ArgList(Identifier,Identifier)),
   FunctionCall(Identifier,ArgList(Identifier,NamedArg(Identifier),Numeric,NamedArg(Identifier),NamedArg(String),Identifier,"...")),
-  FunctionCall(String,ArgList))
+  FunctionCall(String,ArgList),
+  VariableAssignment(Assignable(Identifier),AssignmentOperator,FunctionCall(Identifier,ArgList(Identifier,"..."))))
 
 # If Else
 


### PR DESCRIPTION
A minor change to move precedence of function calls above that of assignment. Without this change
```
foo <- fn(arg)
```
is parsed similarly to `(foo <- fn)(arg)`, with the result:

```
FunctionCall(VariableAssignment(Assignable(Identifier),AssignmentOperator,Identifier),ArgList(Identifier))
```

After this change, we get:

```
VariableAssignment(Assignable(Identifier),AssignmentOperator,FunctionCall(Identifier,ArgList(Identifier)))
```

Apologies for missing this as part of my previous PR's patchset last week, I only just noticed the issue.